### PR TITLE
Facebook/Instagram - updated graph version to 22

### DIFF
--- a/src/Embera/Provider/Facebook.php
+++ b/src/Embera/Provider/Facebook.php
@@ -26,7 +26,7 @@ use Embera\Url;
 class Facebook extends ProviderAdapter implements ProviderInterface
 {
     /** inline {@inheritdoc} */
-    protected $endpoint = 'https://graph.facebook.com/v16.0/oembed_{type}';
+    protected $endpoint = 'https://graph.facebook.com/v22.0/oembed_{type}';
 
     /** inline {@inheritdoc} */
     protected static $hosts = [

--- a/src/Embera/Provider/Instagram.php
+++ b/src/Embera/Provider/Instagram.php
@@ -26,7 +26,7 @@ use Embera\Url;
 class Instagram extends ProviderAdapter implements ProviderInterface
 {
     /** inline {@inheritdoc} */
-    protected $endpoint = 'https://graph.facebook.com/v21.0/instagram_oembed';
+    protected $endpoint = 'https://graph.facebook.com/v22.0/instagram_oembed';
 
     /** inline {@inheritdoc} */
     protected static $hosts = [


### PR DESCRIPTION
Graph API v16.0 will reach the end of its lifetime on 14 May, 2025